### PR TITLE
microposts interface testのコードを修正

### DIFF
--- a/7_0/ch13/test/integration/microposts_interface_test.rb
+++ b/7_0/ch13/test/integration/microposts_interface_test.rb
@@ -34,7 +34,7 @@ class MicropostsInterfaceTest < MicropostsInterface
   end
 
   test "should have micropost delete links on own profile page" do
-    get users_path(@user)
+    get user_path(@user)
     assert_select 'a', text: 'delete'
   end
 

--- a/7_0/ch14/test/integration/microposts_interface_test.rb
+++ b/7_0/ch14/test/integration/microposts_interface_test.rb
@@ -34,7 +34,7 @@ class MicropostsInterfaceTest < MicropostsInterface
   end
 
   test "should have micropost delete links on own profile page" do
-    get users_path(@user)
+    get user_path(@user)
     assert_select 'a', text: 'delete'
   end
 


### PR DESCRIPTION
ユーザープロフィール画面のURLであるはずがユーザー一覧画面のURLになっていたため修正依頼です。

[テキストの13.59](https://railstutorial.jp/chapters/user_microposts?version=7.0#sec-micropost_tests)もusers_pathになっていました。