### PR TITLE
第7版対応のコードで用語のブレを統一化した

### DIFF
--- a/7_0/ch09/app/helpers/sessions_helper.rb
+++ b/7_0/ch09/app/helpers/sessions_helper.rb
@@ -4,7 +4,7 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember(user)
     user.remember
     cookies.permanent.encrypted[:user_id] = user.id

--- a/7_0/ch09/app/models/user.rb
+++ b/7_0/ch09/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))

--- a/7_0/ch10/app/helpers/sessions_helper.rb
+++ b/7_0/ch10/app/helpers/sessions_helper.rb
@@ -8,7 +8,7 @@ module SessionsHelper
     session[:session_token] = user.session_token
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember(user)
     user.remember
     cookies.permanent.encrypted[:user_id] = user.id

--- a/7_0/ch10/app/models/user.rb
+++ b/7_0/ch10/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))

--- a/7_0/ch11/app/helpers/sessions_helper.rb
+++ b/7_0/ch11/app/helpers/sessions_helper.rb
@@ -8,7 +8,7 @@ module SessionsHelper
     session[:session_token] = user.session_token
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember(user)
     user.remember
     cookies.permanent.encrypted[:user_id] = user.id

--- a/7_0/ch11/app/models/user.rb
+++ b/7_0/ch11/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))

--- a/7_0/ch12/app/helpers/sessions_helper.rb
+++ b/7_0/ch12/app/helpers/sessions_helper.rb
@@ -8,7 +8,7 @@ module SessionsHelper
     session[:session_token] = user.session_token
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember(user)
     user.remember
     cookies.permanent.encrypted[:user_id] = user.id

--- a/7_0/ch12/app/models/user.rb
+++ b/7_0/ch12/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))

--- a/7_0/ch13/app/helpers/sessions_helper.rb
+++ b/7_0/ch13/app/helpers/sessions_helper.rb
@@ -8,7 +8,7 @@ module SessionsHelper
     session[:session_token] = user.session_token
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember(user)
     user.remember
     cookies.permanent.encrypted[:user_id] = user.id

--- a/7_0/ch13/app/models/user.rb
+++ b/7_0/ch13/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))

--- a/7_0/ch14/app/helpers/sessions_helper.rb
+++ b/7_0/ch14/app/helpers/sessions_helper.rb
@@ -8,7 +8,7 @@ module SessionsHelper
     session[:session_token] = user.session_token
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember(user)
     user.remember
     cookies.permanent.encrypted[:user_id] = user.id

--- a/7_0/ch14/app/models/user.rb
+++ b/7_0/ch14/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  # 永続セッションのためにユーザーをデータベースに記憶する
+  # 永続的セッションのためにユーザーをデータベースに記憶する
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))


### PR DESCRIPTION
第7版対応（`7_0` フォルダ内）のコードで以下の変更を行いました🛠

```diff
- 永続セッション
+ 永続的セッション
```

軽微な修正のため、テストが通ったらマージします🙏