### PR TITLE
following, followers のステータス指定部分を削除

### DIFF
--- a/7_0/ch14/app/controllers/users_controller.rb
+++ b/7_0/ch14/app/controllers/users_controller.rb
@@ -50,14 +50,14 @@ class UsersController < ApplicationController
     @title = "Following"
     @user  = User.find(params[:id])
     @users = @user.following.paginate(page: params[:page])
-    render 'show_follow', status: :unprocessable_entity
+    render 'show_follow'
   end
 
   def followers
     @title = "Followers"
     @user  = User.find(params[:id])
     @users = @user.followers.paginate(page: params[:page])
-    render 'show_follow', status: :unprocessable_entity
+    render 'show_follow'
   end
 
   private

--- a/7_0/ch14/test/integration/following_test.rb
+++ b/7_0/ch14/test/integration/following_test.rb
@@ -13,7 +13,7 @@ class FollowPagesTest < Following
 
   test "following page" do
     get following_user_path(@user)
-    assert_response :unprocessable_entity
+    assert_response :success
     assert_not @user.following.empty?
     assert_match @user.following.count.to_s, response.body
     @user.following.each do |user|
@@ -23,7 +23,7 @@ class FollowPagesTest < Following
 
   test "followers page" do
     get followers_user_path(@user)
-    assert_response :unprocessable_entity
+    assert_response :success
     assert_not @user.followers.empty?
     assert_match @user.followers.count.to_s, response.body
     @user.followers.each do |user|


### PR DESCRIPTION
Webテキストの更新に合わせ、`7_0` の `ch14` で以下の修正を行いました🛠

- following, followers アクションからステータス指定部分を削除
- 関連するテストを修正