### PR TITLE
7_0 ディレクトリ以下の各章の Ruby バージョンを現行版に合わせて 3.2.5 に更新

### DIFF
--- a/7_0/ch01/Gemfile
+++ b/7_0/ch01/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"

--- a/7_0/ch01/Gemfile.lock
+++ b/7_0/ch01/Gemfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch02/Gemfile
+++ b/7_0/ch02/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"

--- a/7_0/ch02/Gemfile.lock
+++ b/7_0/ch02/Gemfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch03/Gemfile
+++ b/7_0/ch03/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"

--- a/7_0/ch03/Gemfile.lock
+++ b/7_0/ch03/Gemfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch04/Gemfile
+++ b/7_0/ch04/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"

--- a/7_0/ch04/Gemfile.lock
+++ b/7_0/ch04/Gemfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch05/Gemfile
+++ b/7_0/ch05/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "bootstrap-sass",  "3.4.1"

--- a/7_0/ch05/Gemfile.lock
+++ b/7_0/ch05/Gemfile.lock
@@ -361,7 +361,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch06/Gemfile
+++ b/7_0/ch06/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "bcrypt",          "3.1.18"

--- a/7_0/ch06/Gemfile.lock
+++ b/7_0/ch06/Gemfile.lock
@@ -364,7 +364,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch07/Gemfile
+++ b/7_0/ch07/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "bcrypt",          "3.1.18"

--- a/7_0/ch07/Gemfile.lock
+++ b/7_0/ch07/Gemfile.lock
@@ -363,7 +363,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch08/Gemfile
+++ b/7_0/ch08/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "bcrypt",          "3.1.18"

--- a/7_0/ch08/Gemfile.lock
+++ b/7_0/ch08/Gemfile.lock
@@ -363,7 +363,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch09/Gemfile
+++ b/7_0/ch09/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "bcrypt",          "3.1.18"

--- a/7_0/ch09/Gemfile.lock
+++ b/7_0/ch09/Gemfile.lock
@@ -363,7 +363,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch10/Gemfile
+++ b/7_0/ch10/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",                   "7.0.4.3"
 gem "bcrypt",                  "3.1.18"

--- a/7_0/ch10/Gemfile.lock
+++ b/7_0/ch10/Gemfile.lock
@@ -371,7 +371,7 @@ DEPENDENCIES
   will_paginate (= 3.3.1)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch11/Gemfile
+++ b/7_0/ch11/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",                   "7.0.4.3"
 gem "bcrypt",                  "3.1.18"

--- a/7_0/ch11/Gemfile.lock
+++ b/7_0/ch11/Gemfile.lock
@@ -371,7 +371,7 @@ DEPENDENCIES
   will_paginate (= 3.3.1)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch12/Gemfile
+++ b/7_0/ch12/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",                   "7.0.4.3"
 gem "bcrypt",                  "3.1.18"

--- a/7_0/ch12/Gemfile.lock
+++ b/7_0/ch12/Gemfile.lock
@@ -371,7 +371,7 @@ DEPENDENCIES
   will_paginate (= 3.3.1)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch13/Gemfile
+++ b/7_0/ch13/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",                      "7.0.4.3"
 gem "image_processing",           "1.12.2"

--- a/7_0/ch13/Gemfile.lock
+++ b/7_0/ch13/Gemfile.lock
@@ -402,7 +402,7 @@ DEPENDENCIES
   will_paginate (= 3.3.1)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6

--- a/7_0/ch14/Gemfile
+++ b/7_0/ch14/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",                      "7.0.4.3"
 gem "image_processing",           "1.12.2"

--- a/7_0/ch14/Gemfile.lock
+++ b/7_0/ch14/Gemfile.lock
@@ -402,7 +402,7 @@ DEPENDENCIES
   will_paginate (= 3.3.1)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
7_0 の各章を codespaces-railstutorial のRuby バージョンに合わせて更新しました。3.2.4 → 3.2.5
codespaces で動作確認を行い、問題なければマージします🙏