### PR TITLE
Reflect Listing 3.37: HTML構造を削除したHomeページ

### DIFF
--- a/7_0/ch03/app/views/static_pages/home.html.erb
+++ b/7_0/ch03/app/views/static_pages/home.html.erb
@@ -1,15 +1,7 @@
 <% provide(:title, "Home") %>
-<!DOCTYPE html>
-<html>
-  <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
-  </head>
-  <body>
-    <h1>Sample App</h1>
-    <p>
-      This is the home page for the
-      <a href="https://railstutorial.jp/">Ruby on Rails Tutorial</a>
-      sample application.
-    </p>
-  </body>
-</html>
+<h1>Sample App</h1>
+<p>
+  This is the home page for the
+  <a href="https://railstutorial.jp/">Ruby on Rails Tutorial</a>
+  sample application.
+</p>


### PR DESCRIPTION
Moved the HTML structure (doctype, html, head, body) out of home.html.erb as per the tutorial refactor in Listing 3.37.

いつも楽しく学ばせていただいております。
「リスト 3.37:HTML構造を削除したHomeページ」の内容が7_0/ch03に反映されていないようでしたのでプルリクをしたためました。

あえて、「リスト 3.37:HTML構造を削除したHomeページ」は反映していないようでしたら、お捨ておきください。
