### PR TITLE
Mailgun の SMTP ポート設定を 2525 に更新（11〜14章）

### DIFF
--- a/7_0/ch11/config/environments/production.rb
+++ b/7_0/ch11/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   host = '<あなたのRenderアプリ名>.onrender.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    :port           => 587,
+    :port           => 2525,
     :address        => 'smtp.mailgun.org',
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],

--- a/7_0/ch12/config/environments/production.rb
+++ b/7_0/ch12/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   host = '<あなたのRenderアプリ名>.onrender.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    :port           => 587,
+    :port           => 2525,
     :address        => 'smtp.mailgun.org',
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],

--- a/7_0/ch13/config/environments/production.rb
+++ b/7_0/ch13/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   host = '<あなたのRenderアプリ名>.onrender.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    :port           => 587,
+    :port           => 2525,
     :address        => 'smtp.mailgun.org',
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],

--- a/7_0/ch14/config/environments/production.rb
+++ b/7_0/ch14/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   host = '<あなたのRenderアプリ名>.onrender.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    :port           => 587,
+    :port           => 2525,
     :address        => 'smtp.mailgun.org',
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],


### PR DESCRIPTION
Render の無料プランで 587 ポートが使用できなくなったため、  代替で提供されている 2525 ポートへ変更しました。  
チュートリアル側の更新に合わせた対応です！

<img width="755" height="663" alt="スクリーンショット 2025-11-28 16 36 41" src="https://github.com/user-attachments/assets/a32c0da5-58c3-49f8-b2d9-2c603dde8a6f" />
